### PR TITLE
Add pinPullup/down block

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "crickit",
-    "version": "0.0.32",
+    "version": "0.0.33",
     "description": "MakeCode support for Adafruit CRICKIT",
     "license": "MIT",
     "dependencies": {

--- a/signals.ts
+++ b/signals.ts
@@ -13,7 +13,7 @@ namespace crickit {
          * set the signal
          */
         //% group="Signals"
-        //% weight=60
+        //% weight=61
         //% blockId=sawpinwrite block="crickit digital write %pin|to %value=toggleHighLow"
         //% pin.fieldEditor="gridpicker"
         //% pin.fieldOptions.width=220
@@ -23,6 +23,25 @@ namespace crickit {
             const dev = saw();
             dev.pinMode(this._pin, 1);
             dev.digitalWrite(this._pin, value);
+        }
+
+        /**
+         * set the pullup or pulldown internal resister
+         */
+        //% group="Signals"
+        //% weight=60
+        //% blockId=sawpinpullupdown block="set crickit pull pin %pin|to %value=toggleHighLow"
+        //% pin.fieldEditor="gridpicker"
+        //% pin.fieldOptions.width=220
+        //% pin.fieldOptions.columns=1
+        //% blockGap=8
+        pinPullupdown(value: boolean) {
+            const dev = saw();
+            if (value) {
+                dev.pinMode(this._pin, seesaw.Seesaw.INPUT_PULLUP);
+            } else {
+                dev.pinMode(this._pin, seesaw.Seesaw.INPUT_PULLDOWN);
+            }
         }
 
         /**


### PR DESCRIPTION
I'd quite like to better match the micro:bit makecode native pin pullup/down block, but I've not managed to figure out how to do that yet. It's probably better to do that work before merging, otherwise it would be unfortunate for any users of the block if it's changed.

By 'matching', I mean the visual style of selecting up/down/none (I currently have high/low) and making use of the enum `PinPullMode`:

https://github.com/microsoft/pxt-common-packages/blob/bb10eb307d9a34d9fc9b5b48d50eebd4bba841e0/libs/core/pinsDigital.cpp#L21-L28

https://github.com/microsoft/pxt-microbit/blob/9ea346bb363ae1d78f53ce3ec5220f62f4b82cfd/libs/core/_locales/core-strings.json#L399

This addresses #11